### PR TITLE
Update bigread2.m

### DIFF
--- a/utilities/bigread2.m
+++ b/utilities/bigread2.m
@@ -1,8 +1,9 @@
 function imData=bigread2(path_to_file,sframe,num2read);
-%reads tiff files in Matlab bigger than 4GB, allows reading from sframe to sframe+num2read-1 frames of the tiff - in other words, you can read page 200-300 without rading in from page 1.  
+%reads tiff files in Matlab bigger than 4GB, allows reading from sframe to sframe+num2read-1 frames of the tiff - in other words, you can read page 200-300 without rading in from page 1.
 %based on a partial solution posted on Matlab Central (http://www.mathworks.com/matlabcentral/answers/108021-matlab-only-opens-first-frame-of-multi-page-tiff-stack)
 %Darcy Peterka 2014, v1.0
-%Darcy Peterka 2014, v1.1 (bugs to dp2403@columbia.edu)
+%Darcy Peterka 2014, v1.1 
+%Darcy Peterka 2016, v1.2(bugs to dp2403@columbia.edu)
 %Program checks for bit depth, whether int or float, and byte order.  Assumes uncompressed, non-negative (i.e. unsigned) data.
 %
 % Usage:  my_data=bigread('path_to_data_file, start frame, num to read);
@@ -40,17 +41,17 @@ if sframe<=0
     sframe=1;
 end
 if num2read<1
-	num2read=1;
+    num2read=1;
 end
 if sframe>num_tot_frames
-	sframe=num_tot_frames;
-	num2read=1;
-	display('starting frame has to be less than number of total frames...');
+    sframe=num_tot_frames;
+    num2read=1;
+    display('starting frame has to be less than number of total frames...');
 end
 if (num2read+sframe<= num_tot_frames+1)
     lastframe=num2read+sframe-1;
 else
-  	num2read=numFrames-sframe+1;
+    num2read=numFrames-sframe+1;
     lastframe=num_tot_frames;
     display('Hmmm...just reading from starting frame until the end');
 end
@@ -60,13 +61,13 @@ bd=info.BitDepth;
 he=info.ByteOrder;
 bo=strcmp(he,'big-endian');
 if (bd==64)
-	form='double';
+    form='double';
 elseif(bd==32)
     form='single'
 elseif (bd==16)
-		form='uint16';
+    form='uint16';
 elseif (bd==8)
-		form='uint8';
+    form='uint8';
 end
 
 
@@ -114,23 +115,41 @@ if strcmpi(form,'uint16') || strcmpi(form,'uint8')
         end
     end
 elseif strcmpi(form,'single')
-    for cnt = sframe:lastframe
-        %cnt;
-        fseek(fp,ofds(cnt),'bof');
-        tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-be')';
-        imData{cnt-sframe+1}=cast(tmp1,'single');
+    if(bo)
+        for cnt = sframe:lastframe
+            %cnt;
+            fseek(fp,ofds(cnt),'bof');
+            tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-be')';
+            imData{cnt-sframe+1}=cast(tmp1,'single');
+        end
+    else
+        for cnt = sframe:lastframe
+            %cnt;
+            fseek(fp,ofds(cnt),'bof');
+            tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-le')';
+            imData{cnt-sframe+1}=cast(tmp1,'single');
+        end
     end
-elseif strcmpi(form,'double')
-    for cnt = sframe:lastframe
-        %cnt;
-        fseek(fp,ofds(cnt),'bof');
-        tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-le.l64')';
-        imData{cnt-sframe+1}=cast(tmp1,'single');
-    end
+    elseif strcmpi(form,'double')
+        if(bo)
+            for cnt = sframe:lastframe
+                %cnt;
+                fseek(fp,ofds(cnt),'bof');
+                tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-be.l64')';
+                imData{cnt-sframe+1}=cast(tmp1,'single');
+            end
+        else
+            for cnt = sframe:lastframe
+                %cnt;
+                fseek(fp,ofds(cnt),'bof');
+                tmp1 = fread(fp, [he_w he_h*mul], form, 0, 'ieee-le.l64')';
+                imData{cnt-sframe+1}=cast(tmp1,'single');
+            end
+        end
 end
-%ieee-le.l64
-
-imData=cell2mat(imData);
-imData=reshape(imData,[he_h*mul,he_w,framenum]);
-fclose(fp);
-display('Finished reading images')
+        %ieee-le.l64
+        
+        imData=cell2mat(imData);
+        imData=reshape(imData,[he_h*mul,he_w,framenum]);
+        fclose(fp);
+        display('Finished reading images')


### PR DESCRIPTION
Fixed bug/added feature so bigread2 pays attention to byte order flag in tiff header on floats and doubles.  Before it didn't pay attention to this on floats/doubles.