### PR TITLE
Fix two resizing bugs

### DIFF
--- a/initialize_components.m
+++ b/initialize_components.m
@@ -149,8 +149,7 @@ if options.noise_norm
     Ain = bsxfun(@times,Ain,max(P.sn(:),min_noise));
     bin = bsxfun(@times,bin,max(P.sn(:),min_noise));
 end
-
-Cin = imresize(Cin, [sum(K), Ts*tsub]);
+Cin = imresize(Cin, [size(Cin, 1), Ts*tsub]);
 fin = imresize(fin, [options.nb, Ts*tsub]);
 if T ~= Ts*tsub
     Cin = padarray(Cin, [0, T-Ts*tsub], 'post');

--- a/utilities/greedyROI_corr.m
+++ b/utilities/greedyROI_corr.m
@@ -37,8 +37,7 @@ end
 Y_std = Y_std(:);
 if ~exist('debug_on', 'var'); debug_on = false; end
 
-d1 = options.d1;
-d2 = options.d2;
+[d1,d2, ~] = size(Y);
 gSig = options.gSig;
 gSiz = options.gSiz;
 if and(isempty(gSiz), isempty(gSig)); gSig = 3; gSiz = 10; end
@@ -53,7 +52,6 @@ psf = ones(gSig)/(gSig^2);
 min_snr = 3;        % minimum value of (peak-median)/sig 
 maxIter = 5;            % iterations for refining results
 sz = 4;            %distance of neighbouring pixels for computing local correlation
-
 if ~ismatrix(Y); Y = reshape(Y, d1*d2, []); end;
 [~, T] = size(Y);       % number of frames
 Ain = zeros(d1*d2, K);  % spatial components


### PR DESCRIPTION
In **initialize_components.m** the variable `Cin` was not properly resized when `K` changed. For example, `K` might have been 128 but the `init_method` only detected 77 components. While `Ain` was resized correctly, `Cin` was not. That lead to an inconsistent state for spatial updates. 

In  **utilities/greedyROI_corr.m**  using `options.d*` is incorrect if spatial downsampling is performed. 