### PR TITLE
greedyROI: clrear data matrix, avoid out-of-memory in nnmf call

### DIFF
--- a/utilities/greedyROI.m
+++ b/utilities/greedyROI.m
@@ -218,6 +218,9 @@ for r = 1:length(K)
 end
 res = reshape(Y,d,T) + repmat(med(:),1,T);
 
+%% clear data matrix from local memory (avoid out-of-memory? see greedyROI_corr.m)
+clear Y
+
 %[b_in,f_in] = nnmf(max(res,0),nb);
 %[b_in,f_in] = nnsvd(max(res,0),nb);
 f_in = [mean(res);rand(nb-1,T)];

--- a/utilities/greedyROI_corr.m
+++ b/utilities/greedyROI_corr.m
@@ -195,6 +195,9 @@ Cin(Cin<0) = 0;
 if save_avi; avi_file.close(); end
 res = bsxfun(@plus, Y, Y_median);
 
+%% clear data matrix from local memory (avoid out-of-memory in nnmf)
+clear Y
+
 %% initialize background
 tsub = max(1, round(T/1000));
 [bin, f] = nnmf(max(res(:, 1:tsub:T), 0), nb);


### PR DESCRIPTION
The local copy of the data matrix Y can be cleared before calling nnmf for the background(s). In greedyROI_corr this avoids an out-of-memory crash during one of the matrix division operations in some of my datasets; in greedyROI I haven't found that to happen, but clearing the local variable shouldn't cause issues. Actually I can't say I understand why matlab's garbage collector doesn't take care of it. 